### PR TITLE
Use WATO runners to run CI

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -18,7 +18,7 @@ jobs:
   build-rocm:
     env:
       IMAGE_NAME: ${{ github.repository }}/rocm
-    runs-on: ubuntu-latest
+    runs-on: slurm-runner-8cpu-2mempercpu-6:00:00time-131072tmpdisk
     permissions:
       contents: read
       packages: write
@@ -68,7 +68,7 @@ jobs:
   build-cuda:
     env:
       IMAGE_NAME: ${{ github.repository }}/cuda
-    runs-on: ubuntu-latest
+    runs-on: slurm-runner-8cpu-2mempercpu-6:00:00time-131072tmpdisk
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -18,7 +18,7 @@ jobs:
   build-rocm:
     env:
       IMAGE_NAME: ${{ github.repository }}/rocm
-    runs-on: slurm-runner-8cpu-2mempercpu-6:00:00time-131072tmpdisk
+    runs-on: slurm-runner-8cpu-2mempercpu-6:00:00time-128tmpdisk
     permissions:
       contents: read
       packages: write
@@ -68,7 +68,7 @@ jobs:
   build-cuda:
     env:
       IMAGE_NAME: ${{ github.repository }}/cuda
-    runs-on: slurm-runner-8cpu-2mempercpu-6:00:00time-131072tmpdisk
+    runs-on: slurm-runner-8cpu-2mempercpu-6:00:00time-128tmpdisk
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -18,7 +18,7 @@ jobs:
   build-rocm:
     env:
       IMAGE_NAME: ${{ github.repository }}/rocm
-    runs-on: slurm-runner-8cpu-2mempercpu-6:00:00time-128tmpdisk
+    runs-on: slurm-runner-16cpu-2mempercpu-6:00:00time-128tmpdisk
     permissions:
       contents: read
       packages: write
@@ -68,7 +68,7 @@ jobs:
   build-cuda:
     env:
       IMAGE_NAME: ${{ github.repository }}/cuda
-    runs-on: slurm-runner-8cpu-2mempercpu-6:00:00time-128tmpdisk
+    runs-on: slurm-runner-16cpu-2mempercpu-6:00:00time-128tmpdisk
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This PR makes use of the WATO CI runners introduced in https://github.com/WATonomous/slurm-gha/pull/24 .

cc @alexboden